### PR TITLE
added handle code for reading batteri level

### DIFF
--- a/protocols/candle.md
+++ b/protocols/candle.md
@@ -87,3 +87,8 @@ http://www.csr.com/products/csr101x-product-family
 #####Example Response
 `Mipow Limited`
 
+0x001f: get batteri level
+---------------------
+current battery level as a percentage from 0% to 100%; see also https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.battery_service.xml
+
+


### PR DESCRIPTION
on my candles i saw values between 20 where the LED is really weak, and 64 with fresh batteries, but it was cheap batteries, so i guess that could be the reason, but it seems to work
